### PR TITLE
mesonpy: only pull patchelf if needed

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -53,7 +53,7 @@ __version__ = '0.4.0'
 
 class _depstr:
     ninja = 'ninja >= 1.10.0'
-    patchelf_wrapper = 'patchelf-wrapper'
+    patchelf = 'patchelf >= 0.11.0'
     wheel = 'wheel >= 0.36.0'  # noqa: F811
 
 
@@ -778,7 +778,10 @@ def get_requires_for_build_wheel(
     dependencies = [_depstr.wheel, _depstr.ninja]
     with _project(config_settings) as project:
         if not project.is_pure and platform.system() == 'Linux':
-            dependencies.append(_depstr.patchelf_wrapper)
+            # we may need patchelf
+            if not shutil.which('patchelf'):  # XXX: This is slightly dangerous.
+                # patchelf not already acessible on the system
+                dependencies.append(_depstr.patchelf)
     return dependencies
 
 

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -10,19 +10,26 @@ from .conftest import cd_package
 
 
 if platform.system() == 'Linux':
-    VENDORING_DEPS = {mesonpy._depstr.patchelf_wrapper}
+    VENDORING_DEPS = {mesonpy._depstr.patchelf}
 else:
     VENDORING_DEPS = set()
 
 
 @pytest.mark.parametrize(
-    ('package', 'expected'),
+    ('package', 'system_patchelf', 'expected'),
     [
-        ('pure', set()),  # pure and no PEP 621
-        ('library', VENDORING_DEPS),  # not pure and not PEP 621
+        ('pure', True, set()),  # pure and system patchelf
+        ('library', True, set()),  # not pure and system patchelf
+        ('pure', False, set()),  # pure and no system patchelf
+        ('library', False, VENDORING_DEPS),  # not pure and no system patchelf
     ]
 )
-def test_get_requires_for_build_wheel(package, expected):
+def test_get_requires_for_build_wheel(mocker, package, expected, system_patchelf):
+    mock = mocker.patch('shutil.which', return_value=system_patchelf)
+
+    if mock.called:  # sanity check for the future if we add another usage
+        mock.assert_called_once_with('patchelf')
+
     with cd_package(package):
         assert set(mesonpy.get_requires_for_build_wheel()) == expected | {
             mesonpy._depstr.wheel,


### PR DESCRIPTION
Also move to the patchelf package instead of patchelf-wrapper as the
it's functionality is no longer needed and patchelf is better
maintained.

Fixed #52

Signed-off-by: Filipe Laíns <lains@riseup.net>