### PR TITLE
Clean up duplicate dependency on ninja

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -54,7 +54,6 @@ __version__ = '0.5.0'
 
 
 class _depstr:
-    ninja = 'ninja >= 1.10.0'
     patchelf = 'patchelf >= 0.11.0'
     wheel = 'wheel >= 0.36.0'  # noqa: F811
 
@@ -801,7 +800,7 @@ def build_sdist(
 def get_requires_for_build_wheel(
     config_settings: Optional[Dict[str, str]] = None,
 ) -> List[str]:
-    dependencies = [_depstr.wheel, _depstr.ninja]
+    dependencies = [_depstr.wheel]
     with _project(config_settings) as project:
         if not project.is_pure and platform.system() == 'Linux':
             # we may need patchelf

--- a/tests/test_pep517.py
+++ b/tests/test_pep517.py
@@ -33,5 +33,4 @@ def test_get_requires_for_build_wheel(mocker, package, expected, system_patchelf
     with cd_package(package):
         assert set(mesonpy.get_requires_for_build_wheel()) == expected | {
             mesonpy._depstr.wheel,
-            mesonpy._depstr.ninja,
         }


### PR DESCRIPTION
`ninja` is a dependency in `pyproject.toml` already, so it can be removed in `__init__.py`.

Follows up on https://github.com/FFY00/meson-python/pull/63#issuecomment-1136311433
