### PR TITLE
Support the maintenance branches of CPython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .mesonpy-native-file.ini
 docs/_build
+*.pyc

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -470,7 +470,7 @@ class Project():
         # check if we are running on an unsupported interpreter
         if self._metadata.requires_python:
             self._metadata.requires_python.prereleases = True
-            if platform.python_version() not in self._metadata.requires_python:
+            if platform.python_version().rstrip('+') not in self._metadata.requires_python:
                 raise MesonBuilderError(
                     f'Unsupported Python version `{platform.python_version()}`, '
                     f'expected `{self._metadata.requires_python}`'


### PR DESCRIPTION
The version reported by the 3.10 CPython branch is "3.10.5+" which fails the
metadata check.

This strips any trailing '+'.