### PR TITLE
BUG: remove `-Dstrip=true` default, it doesn't work on macOS

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -487,7 +487,6 @@ class Project():
                 f'--native-file={os.fspath(self._meson_native_file)}',
                 # TODO: Allow configuring these arguments
                 '-Ddebug=false',
-                '-Dstrip=true',
                 '-Doptimization=2',
                 *setup_args,
             )


### PR DESCRIPTION
See https://github.com/scipy/scipy/issues/16446 for details on how it fails on macOS and also for proof that it is not needed because it does not change the wheel size on Linux.

This was originally discussed in gh-27. It looks like I was wrong there about the need for stripping. That info was based on my experience with `numpy.distutils` builds; there it is needed because of the hardcoded debug flags that cannot be switched with a flag like `-Ddebug=false` like we use in `meson-python`.