### PR TITLE
TST: fix a failing test which assumes it's running in a git repo

### DIFF
--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -4,6 +4,10 @@ import os
 import tarfile
 import textwrap
 
+from pathlib import Path
+
+import pytest
+
 import mesonpy
 
 from .conftest import in_git_repo_context
@@ -36,6 +40,12 @@ def test_contents_subdirs(sdist_subdirs):
     }
 
 
+in_git_repo = (Path(__file__).resolve().parent / '.git').exists()
+
+
+@pytest.mark.skipif(
+    not in_git_repo, reason='Must be in git repo, cannot create sdist from sdist'
+)
 def test_contents_unstaged(package_pure, tmpdir):
     new_data = textwrap.dedent('''
     def bar():


### PR DESCRIPTION
Running tests from an sdist is important for packagers, and should work without failures. So simply skip the one test that assumes it is running in a git repo.

Closes gh-65
Closes gh-86