### PR TITLE
TST: fix module name in a the purelib-and-platlib C extension

### DIFF
--- a/tests/packages/purelib-and-platlib/plat.c
+++ b/tests/packages/purelib-and-platlib/plat.c
@@ -18,7 +18,7 @@ static struct PyModuleDef module = {
     methods,
 };
 
-PyMODINIT_FUNC PyInit_foo(void)
+PyMODINIT_FUNC PyInit_plat(void)
 {
     return PyModule_Create(&module);
 }


### PR DESCRIPTION
The second argument to `PyModuleDef` is the module name, and that should match the `PyInit_modulename` and the name used in `py.extension_module('modulename')`.

Note that this is somewhat related to gh-93, and I found this when looking at that issue. The test that exercises this code is marked as `xfail` though, so this PR only prevents a possible future issue with this test.