### PR TITLE
TST: fix tests for pyproject-metadata 0.6.1

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -27,6 +27,7 @@ def test_pep621(sdist_full_metadata):
         Author: Jane Doe
         Author-Email: Unknown <jhon.doe@example.com>
         Maintainer-Email: Jane Doe <jane.doe@example.com>
+        License: some license
         Classifier: Development Status :: 4 - Beta
         Classifier: Programming Language :: Python
         Project-URL: Homepage, https://example.com


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>