### PR TITLE
REL: update version to 0.7.0.dev0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('mesonpy', version: '0.6.0')
+project('mesonpy', version: '0.7.0.dev0')
 
 py_mod = import('python')
 py = py_mod.find_installation()

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -50,7 +50,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     import wheel.wheelfile  # noqa: F401
 
 
-__version__ = '0.6.0'
+__version__ = '0.7.0.dev0'
 
 
 class _depstr:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 
 [project]
 name = 'meson-python'
-version = '0.6.0'
+version = '0.7.0.dev0'
 description = 'Meson Python build backend (PEP 517)'
 readme = 'README.md'
 requires-python = '>=3.7'


### PR DESCRIPTION
This is good practice I think, but more importantly: it makes it easy to distinguish between versions installed from source during development and versions installed from PyPI or conda-forge. It has happened to me multiple times already that I see a possible issue in SciPy that may be related, or that I know is fixed in `main` but not the latest release, and want to check the version to distinguish between those two.

I suggest to make a commit like this right after a version is tagged. One thing to discuss: should it be `0.7.0.dev0` or `0.6.1.dev0`? I'm used to the former because of maintaining separate release branches to make bugfix-only releases from.