### PR TITLE
BUG: preserve file permissions for sdist

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -863,7 +863,9 @@ class Project():
                     continue
 
                 info = tarfile.TarInfo(member.name)
-                info.size = os.path.getsize(path)
+                file_stat = os.stat(path)
+                info.size = file_stat.st_size
+                info.mode = int(oct(file_stat.st_mode)[-3:])
 
                 # rewrite the path if necessary, to match the sdist distribution name
                 if dist_name != meson_dist_name:

--- a/tests/packages/executable-bit/example-script.py
+++ b/tests/packages/executable-bit/example-script.py
@@ -1,0 +1,3 @@
+#!python
+
+print('hello!')

--- a/tests/packages/executable-bit/example.c
+++ b/tests/packages/executable-bit/example.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main() {
+	printf("hello!");
+}

--- a/tests/packages/executable-bit/executable_module.py
+++ b/tests/packages/executable-bit/executable_module.py
@@ -1,0 +1,6 @@
+def foo():
+    return 'bar'
+
+
+if __name__ == '__main__':
+    print('foo?', foo())

--- a/tests/packages/executable-bit/meson.build
+++ b/tests/packages/executable-bit/meson.build
@@ -1,0 +1,20 @@
+project(
+    'executable-bit', 'c',
+    version: '1.0.0',
+)
+
+py_mod = import('python')
+py = py_mod.find_installation()
+
+executable(
+    'example', 'example.c',
+    install: true,
+)
+
+install_data(
+    'example-script.py',
+    rename: 'example-script',
+    install_dir: get_option('bindir'),
+)
+
+py.install_sources('executable_module.py')

--- a/tests/packages/executable-bit/pyproject.toml
+++ b/tests/packages/executable-bit/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -4,6 +4,8 @@ import os
 import tarfile
 import textwrap
 
+import pytest
+
 import mesonpy
 
 from .conftest import in_git_repo_context
@@ -66,3 +68,17 @@ def test_contents_unstaged(package_pure, tmpdir):
     }
     read_data = sdist.extractfile('pure-1.0.0/pure.py').read().replace(b'\r\n', b'\n')
     assert read_data == new_data.encode()
+
+
+@pytest.mark.skipif(os.name == 'nt', reason='Executable bit does not exist on Windows')
+def test_executable_bit(sdist_executable_bit):
+    sdist = tarfile.open(sdist_executable_bit, 'r:gz')
+
+    assert set((tar.name, tar.mode) for tar in sdist.getmembers()) == {
+        ('executable_bit-1.0.0/PKG-INFO', 420),
+        ('executable_bit-1.0.0/example-script.py', 755),
+        ('executable_bit-1.0.0/example.c', 644),
+        ('executable_bit-1.0.0/executable_module.py', 755),
+        ('executable_bit-1.0.0/meson.build', 644),
+        ('executable_bit-1.0.0/pyproject.toml', 644),
+    }


### PR DESCRIPTION
Closes gh-82

Note that the bug report is only about the sdist. The wheel generation uses `shutil.copy2`, which should do the right thing already.