### PR TITLE
MAINT: ensure minimum Meson version is consistent in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
   'colorama; os_name == "nt"',
-  'meson>=0.60.0',
+  'meson>=0.62.0',
   'ninja',
   'pyproject-metadata>=0.5.0', # not a hard dependency, only needed for projects that use PEP 621 metadata
   'tomli>=1.0.0',


### PR DESCRIPTION
This dependency was bumped from 0.60.0 to 0.62.0 in gh-58, but only in one of the two places where it was needed. These two places should probably always be kept consistent with each other, even though technically it's not _required_.