### PR TITLE
Fix sdist permissions

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -870,7 +870,7 @@ class Project():
                 info = tarfile.TarInfo(member.name)
                 file_stat = os.stat(path)
                 info.size = file_stat.st_size
-                info.mode = int(oct(file_stat.st_mode)[-3:])
+                info.mode = int(oct(file_stat.st_mode)[-3:], 8)
 
                 # rewrite the path if necessary, to match the sdist distribution name
                 if dist_name != meson_dist_name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = 'mesonpy'
 backend-path = ['.']
 requires = [
-  'meson>=0.62.0',
+  'meson',
   'ninja',
   'pyproject-metadata>=0.5.0',
   'tomli>=1.0.0',

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -76,9 +76,12 @@ def test_executable_bit(sdist_executable_bit):
 
     assert set((tar.name, tar.mode) for tar in sdist.getmembers()) == {
         ('executable_bit-1.0.0/PKG-INFO', 420),
-        ('executable_bit-1.0.0/example-script.py', 755),
-        ('executable_bit-1.0.0/example.c', 644),
-        ('executable_bit-1.0.0/executable_module.py', 755),
-        ('executable_bit-1.0.0/meson.build', 644),
-        ('executable_bit-1.0.0/pyproject.toml', 644),
+        # We match the executable bit on everything
+        # but PKG-INFO(we create this ourselves)
+        # Note: File perms are in octal, but Python returns it in int
+        ('executable_bit-1.0.0/example-script.py', int('755', 8)),
+        ('executable_bit-1.0.0/example.c', int('644', 8)),
+        ('executable_bit-1.0.0/executable_module.py', int('755', 8)),
+        ('executable_bit-1.0.0/meson.build', int('644', 8)),
+        ('executable_bit-1.0.0/pyproject.toml', int('644', 8)),
     }


### PR DESCRIPTION
closes #120 
Read octal permissions as octal, not as base 10.

Right now, it is a coincidence that the last 3 digits of the octal string can be parsed as a base 10 integer, leading to invalid permissions.

We should parse them as octal, instead.