### PR TITLE
BUG: fix native file override

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -614,7 +614,7 @@ class Project():
         # write the native file
         native_file_data = textwrap.dedent(f'''
             [binaries]
-            python3 = '{sys.executable}'
+            python = '{sys.executable}'
         ''')
         native_file_mismatch = (
             not self._meson_native_file.exists()


### PR DESCRIPTION
This attempted to override "python3", which Meson never used for find_installation. So the native file did nothing.

Override the correct name.