### PR TITLE
MAINT: skip setting rpath if it's not needed

### DIFF
--- a/mesonpy/_elf.py
+++ b/mesonpy/_elf.py
@@ -17,7 +17,7 @@ class ELF:
         self._needed: Optional[Collection[str]] = None
 
     def _patchelf(self, *args: str) -> str:
-        return subprocess.check_output(['patchelf', *args, self._path]).decode()
+        return subprocess.check_output(['patchelf', *args, self._path], stderr=subprocess.STDOUT).decode()
 
     @property
     def rpath(self) -> Collection[str]:

--- a/mesonpy/_elf.py
+++ b/mesonpy/_elf.py
@@ -23,7 +23,7 @@ class ELF:
     def rpath(self) -> Collection[str]:
         if self._rpath is None:
             rpath = self._patchelf('--print-rpath').strip()
-            self._rpath = rpath.split(';') if rpath else []
+            self._rpath = rpath.split(':') if rpath else []
         return frozenset(self._rpath)
 
     @rpath.setter

--- a/mesonpy/_elf.py
+++ b/mesonpy/_elf.py
@@ -21,9 +21,10 @@ class ELF:
 
     @property
     def rpath(self) -> Collection[str]:
-        if not self._rpath:
-            self._rpath = self._patchelf('--print-rpath').strip().split(';')
-        return self._rpath
+        if self._rpath is None:
+            rpath = self._patchelf('--print-rpath').strip()
+            self._rpath = rpath.split(';') if rpath else []
+        return frozenset(self._rpath)
 
     @rpath.setter
     def rpath(self, value: Collection[str]) -> None:

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -247,7 +247,16 @@ def test_detect_wheel_tag_script(wheel_executable):
 
 
 @pytest.mark.skipif(platform.system() != 'Linux', reason='Unsupported on this platform for now')
-def test_unneeded_rpath(wheel_purelib_and_platlib, tmpdir):
+def test_rpath(wheel_link_against_local_lib, tmpdir):
+    artifact = wheel.wheelfile.WheelFile(wheel_link_against_local_lib)
+    artifact.extractall(tmpdir)
+
+    elf = mesonpy._elf.ELF(tmpdir / f'example{EXT_SUFFIX}')
+    assert '$ORIGIN/.link_against_local_lib.mesonpy.libs' in elf.rpath
+
+
+@pytest.mark.skipif(platform.system() != 'Linux', reason='Unsupported on this platform for now')
+def test_uneeded_rpath(wheel_purelib_and_platlib, tmpdir):
     artifact = wheel.wheelfile.WheelFile(wheel_purelib_and_platlib)
     artifact.extractall(tmpdir)
 


### PR DESCRIPTION
I also fixed `ELF.rpath`, which is needed for the tests, and added a test for setting the rpath in the first place in this PR.

Fixes #125