### PR TITLE
CI: fix triggers for Sage CI jobs

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -34,19 +34,17 @@ name: Run Sage CI for Linux
 ## Many copies of the second step are run in parallel for each of the tested
 ## systems/configurations.
 
-on: [push, pull_request, workflow_dispatch]
-
-## Uncomment this (and comment the above) to run only on pushes to a tag,
-## not on all pushes to a branch.
-##
-## on:
-##   pull_request:
-##     types: [opened, synchronize]
-##   push:
-##     tags:
-##       - '*'
-##   workflow_dispatch:
-##     # Allow to run manually
+on:
+  pull_request:
+    branches:
+      - main
+      - release-*
+  push:
+    branches:
+      - main
+      - release-*
+  workflow_dispatch:
+    # Allow to run manually
 
 env:
   # Ubuntu packages to install so that the project's can build an sdist


### PR DESCRIPTION
They were firing in duplicate when a push was made to a branch and a PR was open from that branch.

In general, triggering on random WIP branches or say a branch created by clicking the "revert" button on a PR is not desired.

Example from gh-135:

<img width="380" alt="image" src="https://user-images.githubusercontent.com/98330/190065944-24fa1f10-7bc5-413c-a8ff-cecba4ea9b61.png">
