### PR TITLE
CI: add concurrency control to GitHub Actions workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -46,6 +46,10 @@ on:
   workflow_dispatch:
     # Allow to run manually
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # Ubuntu packages to install so that the project's can build an sdist
   DIST_PREREQ:      python3-pip

--- a/.github/workflows/tests-cygwin.yml
+++ b/.github/workflows/tests-cygwin.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     runs-on: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
This ensures that multiple jobs don't run for the same action. If a new commit is pushed, this cancels the jobs for the older commit. This is typically what is desired, and especially for longer-running jobs.