### PR TITLE
Use `mac_ver` instead of `sysconfig.get_platform` when determining the platform tag and document the MacOS platform tag handling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,6 +148,7 @@ If you really need the data to be installed where it was previously (eg.
 
    usage/start
    usage/build-options
+   usage/specific-behaviors
 
 
 .. toctree::

--- a/docs/usage/specific-behaviors.rst
+++ b/docs/usage/specific-behaviors.rst
@@ -1,0 +1,17 @@
+******************
+Specific Behaviors
+******************
+
+This page documents how our backend handles certain situations.
+
+
+``MACOSX_DEPLOYMENT_TARGET``
+============================
+
+
+The target macOS version can by changed by setting the
+``MACOSX_DEPLOYMENT_TARGET`` environment variable.
+
+If ``MACOSX_DEPLOYMENT_TARGET`` is set, we will use the selected version for the
+wheel tag, otherwise ``platform.mac_ver()`` (i.e., the current macOS version on
+the build machine) will be used instead.

--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -269,6 +269,12 @@ class _WheelBuilder():
                     'platform tag to {target}{reset}'.format(target=target, **_STYLES)
                 )
                 parts[1] = target
+            else:
+                # If no target macOS version is specified fallback to
+                # platform.mac_ver() instead of sysconfig.get_platform() as the
+                # latter specifies the target macOS version Python was built
+                # against.
+                parts[1] = platform.mac_ver()[0]
 
             if parts[1] in ('11', '12'):
                 # Workaround for bug where pypa/packaging does not consider macOS

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -48,7 +48,12 @@ elif platform.python_implementation() == 'PyPy':
 else:
     raise NotImplementedError(f'Unknown implementation: {platform.python_implementation()}')
 
-PLATFORM_TAG = sysconfig.get_platform().replace('-', '_').replace('.', '_')
+platform_ = sysconfig.get_platform()
+if platform.system() == 'Darwin':
+    parts = platform_.split('-')
+    parts[1] = platform.mac_ver()[0]
+    platform_ = '-'.join(parts)
+PLATFORM_TAG = platform_.replace('-', '_').replace('.', '_')
 
 if platform.system() == 'Linux':
     SHARED_LIB_EXT = 'so'
@@ -116,7 +121,7 @@ def test_scipy_like(wheel_scipy_like):
     name = artifact.parsed_filename
     assert name.group('pyver') == PYTHON_TAG
     assert name.group('abi') == INTERPRETER_TAG
-    assert name.group('plat') == sysconfig.get_platform().replace('-', '_').replace('.', '_')
+    assert name.group('plat') == PLATFORM_TAG
 
     # Extra checks to doubly-ensure that there are no issues with erroneously
     # considering a package with an extension module as pure
@@ -236,14 +241,14 @@ def test_detect_wheel_tag_module(wheel_purelib_and_platlib):
     name = wheel.wheelfile.WheelFile(wheel_purelib_and_platlib).parsed_filename
     assert name.group('pyver') == PYTHON_TAG
     assert name.group('abi') == INTERPRETER_TAG
-    assert name.group('plat') == sysconfig.get_platform().replace('-', '_').replace('.', '_')
+    assert name.group('plat') == PLATFORM_TAG.replace('-', '_').replace('.', '_')
 
 
 def test_detect_wheel_tag_script(wheel_executable):
     name = wheel.wheelfile.WheelFile(wheel_executable).parsed_filename
     assert name.group('pyver') == 'py3'
     assert name.group('abi') == 'none'
-    assert name.group('plat') == sysconfig.get_platform().replace('-', '_').replace('.', '_')
+    assert name.group('plat') == PLATFORM_TAG.replace('-', '_').replace('.', '_')
 
 
 @pytest.mark.skipif(platform.system() != 'Linux', reason='Unsupported on this platform for now')


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>