### PR TITLE
BUG: also handle macOS 10.X versions correctly

### DIFF
--- a/mesonpy/__init__.py
+++ b/mesonpy/__init__.py
@@ -275,9 +275,11 @@ class _WheelBuilder():
                 # latter specifies the target macOS version Python was built
                 # against.
                 parts[1] = platform.mac_ver()[0]
-                # Only pick up the major version
-                # https://github.com/FFY00/meson-python/issues/160
-                parts[1] = parts[1].split('.')[0]
+                if parts[1] >= '11':
+                    # Only pick up the major version, which changed from 10.X
+                    # to X.0 from macOS 11 onwards. See
+                    # https://github.com/FFY00/meson-python/issues/160
+                    parts[1] = parts[1].split('.')[0]
 
             if parts[1] in ('11', '12'):
                 # Workaround for bug where pypa/packaging does not consider macOS

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -51,7 +51,9 @@ else:
 platform_ = sysconfig.get_platform()
 if platform.system() == 'Darwin':
     parts = platform_.split('-')
-    parts[1] = platform.mac_ver()[0].split('.')[0]
+    parts[1] = platform.mac_ver()[0]
+    if parts[1] >= '11':
+        parts[1] = parts[1].split('.')[0]
     if parts[1] in ('11', '12'):
         parts[1] += '.0'
     platform_ = '-'.join(parts)


### PR DESCRIPTION
This is a follow-up to gh-161. From my review comment there:

However, the logic is wrong for macOS 10.x - there we _do_ want to preserve the major version, it should result in (e.g.) `10_13` and not `10_0`.