### PR TITLE
CI: update opensuse platforms

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -97,7 +97,8 @@ jobs:
            "centos-stream-8",
            "gentoo-python3.9",
            "archlinux-latest",
-           "opensuse-15.4",
+           "opensuse-15.4-gcc_11",
+           "opensuse-tumbleweed",
            "conda-forge",
            ]
       tox_packages_factors: >-


### PR DESCRIPTION
Adding `opensuse-tumbleweed` as discussed in #172 @rgommers

Changing `opensuse-15.4` to `opensuse-15.4-gcc_11` to track a change in https://trac.sagemath.org/ticket/34266